### PR TITLE
Dirty hack to support macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools",
+  "wheel",
+  "numpy",
+  "Cython",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,23 @@
+import sys
+
 from setuptools import setup, Extension
 from Cython.Build import cythonize
 import numpy as np
 
 
+extra_compile_args = []
+extra_link_args = []
+# macOS Clang doesn't support OpenMP
+if sys.platform != 'darwin':
+    extra_compile_args.append('-fopenmp')
+    extra_link_args.append('-fopenmp')
+
+
 extensions = [Extension("coniferest.calc_mean_paths",
                         ["coniferest/calc_mean_paths.pyx"],
                         include_dirs=[np.get_include()],
-                        extra_compile_args=['-fopenmp'],
-                        extra_link_args=['-fopenmp'],
+                        extra_compile_args=extra_compile_args,
+                        extra_link_args=extra_link_args,
                         )]
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extensions = [Extension("coniferest.calc_mean_paths",
 
 setup(name='coniferest',
       description='Coniferous forests for better machine learning',
-      version='dev',
+      version='0.0.1-alpha.0',
       author='Vladimir Korolev',
       author_email='balodja@gmail.com',
       packages=['coniferest'],


### PR DESCRIPTION
macOS LLVM installation doesn't support OpenMP, so clang fails if `-fopenmp` is given. However macOS users can install LLVM or GCC with OpenMP support, but I would say it is rear case. This commit removes `-fopenmp` flags for macOS completely making it possible to compile non-parallel version of the package on this weird platform.