### PR TITLE
Fix AADForest.fit_known()

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -56,7 +56,7 @@ def test_e2e_ztf_m31():
 @pytest.mark.parametrize(
     "model,n_iter,last_idx",
     [
-        (AADForest(n_trees=128, random_seed=0), 91, 1093),
+        (AADForest(n_trees=128, random_seed=0), 46, 1117),
         (PineForest(n_trees=128, n_spare_trees=512, random_seed=0), 34, 1109),
     ],
 )


### PR DESCRIPTION
`AADForest.fit_known()` never worked because losses and gradients it optimizes were zeros. It was caused by a nasty typing bug fixed in #77. Also it finished work started in #62, since that PR didn't do everything needed for making AAD scores negative.

- Since scores are negative now, we should use (1.0-tau) quantile instead of just tau used in the original implementation. I also changed definition of local variable `scores` (anomaly scores minus quantile) and corrected loss gradient.

**Known issues**

- I'm not sure how it was before, but now minimization of weights does not converge, try `test_non_anomalous_outliers` and debug for minimization result to see it. It may mean that I did something wrong with gradients

Closes #75