### PR TITLE
Fix known_labels type in `Session.run()`

### DIFF
--- a/coniferest/aadforest.py
+++ b/coniferest/aadforest.py
@@ -172,6 +172,9 @@ class AADForest(Coniferest):
         self
         """
 
+        known_data = np.asarray(known_data) if known_data is not None else None
+        known_labels = np.asarray(known_labels) if known_labels is not None else None
+
         self._build_trees(data)
 
         if known_data is None or len(known_data) == 0 or \

--- a/coniferest/pineforest.py
+++ b/coniferest/pineforest.py
@@ -168,6 +168,10 @@ class PineForest(Coniferest):
         -------
         self
         """
+
+        known_data = np.asarray(known_data) if known_data is not None else None
+        known_labels = np.asarray(known_labels) if known_labels is not None else None
+
         if self.regenerate_trees:
             self.trees = []
 

--- a/coniferest/session/__init__.py
+++ b/coniferest/session/__init__.py
@@ -133,7 +133,7 @@ class Session:
 
         while not self._terminated:
             known_data = self._data[list(self._known_labels.keys())]
-            known_labels = list(self._known_labels.values())
+            known_labels = np.fromiter(self._known_labels.values(), dtype=int, count=len(self._known_labels))
             self.model.fit_known(self._data, known_data, known_labels)
 
             self._invoke_callbacks(self._on_refit_cb, self)


### PR DESCRIPTION
Both `PineForest` and `AADForest` models implicitly expect that `known_labels` is `numpy` array. See jupyter notebooks for the reference.