### PR TITLE
Allow compiling with openMP on macOS

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,27 +7,42 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Wheels on ${{ matrix.os }} with CIBW_ARCHS=${{ matrix.archs }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # Numpy provides wheels for x86_64 and aarch64 only, we do the same
+        include:
+          - os: ubuntu-latest
+            archs: x86_64 aarch64
+          - os: macos-latest
+            archs: x86_64
+          - os: macos-latest
+            archs: arm64
+          - os: windows-latest
+            archs: auto
     steps:
     - uses: actions/checkout@v3
     - name: Set up QEMU
-      if: runner.os == 'Linux'
+      if: ${{ runner.os == 'Linux' }}
       uses: docker/setup-qemu-action@v2
       with:
         platforms: all
+    - name: Set up OpenMP
+      # We cannot make OpenMP work for cross-compiled ARM64 macOS wheels, so we do it for x86_64 only
+      if: ${{ runner.os == 'macOS' && matrix.archs == 'x86_64' }}
+      # For OpenMP support we use the LLVM toolchain from Homebrew with libomp.
+      # It looks like LLVM gives faster code than GCC does.
+      run: |
+        brew install llvm libomp
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CONIFEREST_FORCE_OPENMP_ON_MACOS=1" >> $GITHUB_ENV
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.13.1
       env:
-        # Numpy provides wheels for x86_64 and aarch64 only, no MUSL support
-        # For building velocity we follow the same pattern
-        CIBW_ARCHS_LINUX: x86_64 aarch64
-        CIBW_ARCHS_MACOS: x86_64 arm64
-        # We do not provide wheels for PyPy
+        CIBW_ARCHS: ${{ matrix.archs }}
+        # We skip MUSL (no numpy binary wheels) and PyPy
         CIBW_SKIP: "pp* *musl*"
     - uses: actions/upload-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ See the documentation for the [**Tutorial**](https://coniferest.readthedocs.io/e
 
 The project is using [Cython](https://cython.org/) for performance and requires compilation.
 However, binary wheels are available for Linux, macOS and Windows, so you can install the package with `pip install coniferest` on these platforms with no build-time dependencies.
+Currently multithreading is not available in macOS ARM wheels, but you can install the package from the source to enable it, see instructions below. 
 
-If your specific platform is not supported, or you need a development version, you can install the package from source.
+If your specific platform is not supported, or you need a development version, you can install the package from the source.
 To do so, clone the repository and run `pip install .` in the root directory.
 
-Note, that we are using OpenMP for multi-threading, which is not available on macOS with a default Clang compiler.
-You still can install the package with Clang, but it will be single-threaded.
-Also, you can install the package with GCC, which is available on macOS via Homebrew.
-In this case you will need to set environment variables `CC=gcc-12` (or whatever version you have installed) and `CONIFEREST_FORCE_OPENMP_ON_MACOS=1`.
+Note, that we are using OpenMP for multi-threading, which is not available on macOS with the Apple LLVM Clang compiler.
+You still can install the package with Apple LLVM, but it will be single-threaded.
+Alternatively, you can install the package with Clang from Homebrew (`brew install llvm libomp`) or GCC (`brew install gcc`), which will enable multi-threading.
+In this case you will need to set environment variables `CC=gcc-12` (or whatever version you have installed) or `CC=$(brew --preifx llvm)/bin/clang` and `CONIFEREST_FORCE_OPENMP_ON_MACOS=1`.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ It includes:
 Install the package with `pip install coniferest`.
 
 See the documentation for the [**Tutorial**](https://coniferest.readthedocs.io/en/latest/tutorial.html).
+
+
+### Installation
+
+The project is using [Cython](https://cython.org/) for performance and requires compilation.
+However, binary wheels are available for Linux, macOS and Windows, so you can install the package with `pip install coniferest` on these platforms with no build-time dependencies.
+
+If your specific platform is not supported, or you need a development version, you can install the package from source.
+To do so, clone the repository and run `pip install .` in the root directory.
+
+Note, that we are using OpenMP for multi-threading, which is not available on macOS with a default Clang compiler.
+You still can install the package with Clang, but it will be single-threaded.
+Also, you can install the package with GCC, which is available on macOS via Homebrew.
+In this case you will need to set environment variables `CC=gcc-12` (or whatever version you have installed) and `CONIFEREST_FORCE_OPENMP_ON_MACOS=1`.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -9,8 +10,8 @@ import numpy as np
 
 extra_compile_args = []
 extra_link_args = []
-# macOS Clang doesn't support OpenMP
-if sys.platform != 'darwin':
+# macOS Clang doesn't support OpenMP, but we allow to force build with it anyway
+if sys.platform != 'darwin' or os.environ.get('CONIFEREST_FORCE_OPENMP_ON_MACOS', False):
     extra_compile_args.append('-fopenmp')
     extra_link_args.append('-fopenmp')
 


### PR DESCRIPTION
With `CC=gcc-XX` and a beautiful env variable CONIFEREST_FORCE_OPENMP_ON_MACOS=1