### PR TITLE
Fix some testing issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ isolated_build = True
 [testenv]
 extras = dev
 commands =
-    pytest -m 'not long'
+    pytest -m 'not long' --durations=0
 """

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -33,7 +33,8 @@ def test_e2e_ztf_m31():
 
     data, metadata = ztf_m31()
     model = AADForest(
-        n_trees=1024,
+        n_trees=128,
+        n_subsamples=256,
         random_seed=0,
     )
     session = Session(
@@ -47,7 +48,7 @@ def test_e2e_ztf_m31():
 
     assert len(session.known_labels) == callback.n_iter
 
-    oid = 695211200035023
+    oid = 695211200075348
     idx = np.where(metadata == oid)[0][0]
     assert idx in session.known_labels
     assert session.known_labels[idx] == Label.ANOMALY

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -14,20 +14,23 @@ from coniferest.session import Session
 def test_e2e_ztf_m31():
     """Basically the same example as in the docs"""
     class Callback():
-        """Say NO for first three objectsm then say YES and terminate"""
+        """Say NO for first few objects, then say YES and terminate"""
         counter = 0
+
+        def __init__(self, n_iter):
+            self.n_iter = n_iter
 
         def decision(self, _metadata, _data, _session) -> Label:
             self.counter += 1
-            if self.counter < 4:
+            if self.counter < self.n_iter:
                 return Label.REGULAR
             return Label.ANOMALY
 
         def on_decision(self, _metadata, _data, session) -> None:
-            if self.counter >= 4:
+            if self.counter >= self.n_iter:
                 session.terminate()
 
-    callback = Callback()
+    callback = Callback(2)
 
     data, metadata = ztf_m31()
     model = AADForest(
@@ -43,9 +46,9 @@ def test_e2e_ztf_m31():
     )
     session.run()
 
-    assert len(session.known_labels) == 4
+    assert len(session.known_labels) == callback.n_iter
 
-    oid = 695211200075348
+    oid = 695211200035023
     idx = np.where(metadata == oid)[0][0]
     assert idx in session.known_labels
     assert session.known_labels[idx] == Label.ANOMALY

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -54,6 +54,9 @@ def test_e2e_ztf_m31():
     assert session.known_labels[idx] == Label.ANOMALY
 
 
+# We mark it long because for some platforms it sometimes takes an hour to run it for the AAD case
+# https://github.com/snad-space/coniferest/issues/121
+@pytest.mark.long
 @pytest.mark.e2e
 @pytest.mark.regression
 @pytest.mark.parametrize(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,7 +9,6 @@ from coniferest.session import Session
 
 
 @pytest.mark.e2e
-@pytest.mark.long
 @pytest.mark.regression
 def test_e2e_ztf_m31():
     """Basically the same example as in the docs"""


### PR DESCRIPTION
- Fix `test_session.test_e2e_ztf_m31`, make it faster and remove pytest "long" mark from it
- `test_non_anomalous_outliers` shows that something is wrong with `AADForest`: it takes an hour to run on Linux and Windows, and just 20 seconds on Mac. I opened #121 for it and mark it "long" with this PR
- Output test durations when run with `tox`