### PR TITLE
Remove formatters from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,6 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: trailing-whitespace # trims trailing whitespace
-    -   id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline
     -   id: check-toml
     -   id: check-yaml
     -   id: check-added-large-files


### PR DESCRIPTION
Since the team is against the idea of `pre-comitt.ci` formatting files (see discussion in #110), I drop most of the formatters from `.pre-commit-config.yaml`