### PR TITLE
Bumpy scikit-learn to 1.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,8 @@ jobs:
       env:
         CIBW_ARCHS: ${{ matrix.archs }}
         # We skip MUSL (no numpy binary wheels) and PyPy
-        CIBW_SKIP: "pp* *musl*"
+        # We skip Python 3.12, onnx 1.15 is not compatible yet
+        CIBW_SKIP: "pp* *musl* cp312-*"
     - uses: actions/upload-artifact@v3
       with:
         path: wheelhouse/*.whl

--- a/coniferest/coniferest.py
+++ b/coniferest/coniferest.py
@@ -138,7 +138,8 @@ class Coniferest(ABC):
                                   max_features=1,
                                   min_samples_leaf=self.min_samples_leaf,
                                   min_weight_leaf=self.min_weight_leaf,
-                                  random_state=splitter_state)
+                                  random_state=splitter_state,
+                                  monotonic_cst=None)
 
         builder_args = {
             'splitter': splitter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ addopts = "--benchmark-min-time=0.1 --benchmark-max-time=5.0 --benchmark-min-rou
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py39,py310,py311
 isolated_build = True
 
 [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "coniferest"
 version = "0.0.11"
 description = "Coniferous forests for better machine learning"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
   { name = "Vladimir Korolev", email = "balodja@gmail.com" },
   { name = "SNAD team" },
@@ -32,7 +32,8 @@ dependencies = [
   # We need it for cpu_count() only, but we have it anyway as a dependency of scikit-learn
   "joblib",
   "numpy",
-  "scikit-learn>=1,<2",
+  # sklearn.tree._splitter.RandomSplitter changed signature in 1.4.0
+  "scikit-learn>=1.4,<2",
   "matplotlib",
   "onnxconverter-common",
 ]
@@ -42,8 +43,6 @@ dev = [
   "pytest",
   "pytest-benchmark[histogram]",
   "onnxruntime",
-  # sciki-learn 1.3 changed pickle format, so we need it for consistency of regression test data
-  "scikit-learn>=1.3",
 ]
 
 [project.urls]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -62,7 +62,7 @@ def test_e2e_ztf_m31():
 @pytest.mark.parametrize(
     "model,n_iter,last_idx",
     [
-        (AADForest(n_trees=128, random_seed=0), 46, 1117),
+        (AADForest(n_trees=128, random_seed=0), 48, 1117),
         (PineForest(n_trees=128, n_spare_trees=512, random_seed=0), 34, 1109),
     ],
 )


### PR DESCRIPTION
`scikit-learn` v1.4 changed some internal interfaces which we use, so we require this new version now.

This also drops the support of python 3.7 and 3.8

Fixes #141