### PR TITLE
Add Plasticc dataset

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include src/coniferest/*.pxd
 include src/coniferest/*.pyx
 include src/coniferest/datasets/*.npz
+include src/coniferest/datasets/*.parquet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
 datasets = [
   # For downloading and parsing DevNet datasets
   "pandas",
+  # For Plasticc dataset
+  "pyarrow",
 ]
 dev = [
   "pytest",

--- a/src/coniferest/datasets/__init__.py
+++ b/src/coniferest/datasets/__init__.py
@@ -1,9 +1,10 @@
 import numpy as np
 from coniferest.label import Label
 
+from .plasticc_gp import plasticc_gp
 from .ztf_m31 import ztf_m31
 
-__all__ = ["ztf_m31", "single_outlier", "non_anomalous_outliers"]
+__all__ = ["ztf_m31", "plasticc_gp", "single_outlier", "non_anomalous_outliers"]
 
 
 class Dataset:

--- a/src/coniferest/datasets/plasticc_gp.py
+++ b/src/coniferest/datasets/plasticc_gp.py
@@ -1,0 +1,29 @@
+from importlib.resources import open_binary
+
+import pandas as pd
+
+from coniferest import datasets
+
+
+def plasticc_gp():
+    """
+    Load PLAsTiCC dataset of GP-approximated light curves.
+
+    It is a subset of the PLAsTiCC dataset, light curves are approximated
+    with vector Gaussian processes (Kornilov et al., 2023). Features
+    are these GP approximations and GP parameters, all normalized.
+
+    Adopted from Ishida et al. 2021:
+    https://ui.adsabs.harvard.edu/abs/2021A%26A...650A.195I/abstract
+
+    Returns
+    -------
+    data : 2-D numpy.ndarray of float32
+        2-D array of features.
+    metadata : 1-D numpy.ndarray of bool
+        1-D array of anomaly labels, True for anomalies.
+    """
+    with open_binary(datasets, "plasticc.parquet") as fh:
+        df = pd.read_parquet(fh)
+        feature_columns = [name for name in df.columns if name.startswith("feature")]
+        return df[feature_columns].to_numpy(), df["answer"].to_numpy(dtype=bool)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from coniferest.datasets import ztf_m31, dev_net_dataset
+from coniferest.datasets import ztf_m31, dev_net_dataset, plasticc_gp
 
 
 def test_ztf_m31():
@@ -23,3 +23,15 @@ def test_dev_net():
 
     assert metadata.shape == (data.shape[0],)
     assert_array_equal(np.unique(metadata), [-1, 1])
+
+
+def test_plasticc_gp():
+    data, metadata = plasticc_gp()
+
+    assert data.shape == (7204, 374)
+    assert data.dtype == np.float32
+    assert_allclose(data.sum(axis=1)[13], 70.540085, atol=1e-6)
+
+    assert metadata.shape == (data.shape[0],)
+    assert metadata.dtype == np.bool_
+    assert metadata.sum() == 277


### PR DESCRIPTION
It adds a parquet file with our Plasticc dataset. It is 14MB, but I believe it is fine for now to have it here