### PR TITLE
Readthedocs: do not build pdf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,10 @@ build:
     # For the iTree visualization notebook
     - graphviz
 
-formats: all
+# PDF build doesn't work, so we exclude it
+formats:
+  - htmlzip
+  - epub
 
 sphinx:
    configuration: docs/conf.py


### PR DESCRIPTION
For some reason PDF doesn't build, and I don't think that we really need it