### PR TITLE
Use use_threads_if in calc_paths_sum to impove score_samples performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "numpy>=2.0",
-    "Cython",
+    "Cython==3.1.0a1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/coniferest/calc_paths_sum.pyx
+++ b/src/coniferest/calc_paths_sum.pyx
@@ -91,16 +91,16 @@ cdef void _paths_sum(selector_t [::1] selectors,
                      np.float64_t [::1] weights=None,
                      int num_threads=1):
 
-    cdef Py_ssize_t trees
+    cdef Py_ssize_t work_per_thread = 200
+    cdef Py_ssize_t trees = indices.shape[0] - 1
     cdef Py_ssize_t tree_index
     cdef Py_ssize_t x_index
     cdef selector_t selector
     cdef Py_ssize_t tree_offset
     cdef np.int32_t feature, i
+    cdef int use_threads_if = (work_per_thread * num_threads < data.shape[0] * trees)
 
-    with nogil, parallel(num_threads=num_threads):
-        trees = indices.shape[0] - 1
-
+    with nogil, parallel(num_threads=num_threads, use_threads_if=use_threads_if):
         for x_index in prange(data.shape[0], schedule='static'):
             for tree_index in range(trees):
                 tree_offset = indices[tree_index]


### PR DESCRIPTION
Currently, we see that multi-threading overhead is considerably high for small datasets in `score_samples` function.

Before the commit:
![image](https://github.com/user-attachments/assets/3b53a7cc-e893-4280-8e11-634dca407c19)

After the commit:
![image](https://github.com/user-attachments/assets/4a72b341-a93e-4232-9fae-241dab8ea542)

I've tested the code at two machines (COIN server and dl580g10 at SAI). The results are consistent.

Possibly fix #212