### PR TITLE
Update requirements in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "numpy>=2.0",
-    "Cython==3.1.0a1",
+    "Cython>=3.1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Cython 3.1 has been released, we don't need alpha version.