### PR TITLE
CI: Separate benchmarks to a new workflow file

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,27 @@
+name: benchmark
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: |
+            pip install -e '.[dev,datasets]'
+            pip install pytest-codspeed
+            python3 -mpytest --codspeed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on: [push, pull_request]
 
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -10,33 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Run tox
-      run: pipx run tox -e py${{ matrix.python-version }}
-
-  benchmark:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup Python 3.12
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.12
-    - name: Run benchmarks
-      uses: CodSpeedHQ/action@v3
-      with:
-        token: ${{ secrets.CODSPEED_TOKEN }}
-        run: |
-          pip install -e '.[dev,datasets]'
-          # https://github.com/CodSpeedHQ/pytest-codspeed/issues/27
-          pip install 'pytest!=8.1.1' pytest-codspeed
-          python3 -mpytest --codspeed
+      - uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run tox
+        run: pipx run tox -e py${{ matrix.python-version }}


### PR DESCRIPTION
Benchmarks take ~90 minutes to run, so let's not run them on all pushes.