### PR TITLE
Fix Sphix documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,3 +30,5 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 html_theme = "alabaster"
 html_static_path = ["_static"]
+
+nbsphinx_execute = 'never'


### PR DESCRIPTION
Disable executing of notebook by Sphinx. We will handle notebook consistency on our own to ensure stable and predictable documentation build time.