### PR TITLE
Handle infinite C_a in AADForest

### DIFF
--- a/src/coniferest/aadforest.py
+++ b/src/coniferest/aadforest.py
@@ -12,10 +12,55 @@ from .label import Label
 __all__ = ["AADForest"]
 
 
+def _validate_coefficient(value, name):
+    if not isinstance(value, Real):
+        raise ValueError(f"{name} is not a real number")
+
+    value = float(value)
+
+    if np.isnan(value) or np.isneginf(value):
+        raise ValueError(f"{name} must be finite or positive infinity")
+
+    return value
+
+
+def _normalize_label_loss_coefficients(C_a, C_n):
+    C_a = _validate_coefficient(C_a, "C_a")
+    C_n = _validate_coefficient(C_n, "C_n")
+
+    infinite_C_a = np.isposinf(C_a)
+    infinite_C_n = np.isposinf(C_n)
+
+    if infinite_C_a and infinite_C_n:
+        raise ValueError("At most one of C_a, C_n and prior_influence can be infinite")
+    if infinite_C_a:
+        return 1.0, 0.0, True
+    if infinite_C_n:
+        return 0.0, 1.0, True
+
+    return C_a, C_n, False
+
+
+def _normalize_loss_coefficients(C_a, C_n, prior_influence):
+    C_a = _validate_coefficient(C_a, "C_a")
+    C_n = _validate_coefficient(C_n, "C_n")
+    prior_influence = _validate_coefficient(prior_influence, "prior_influence")
+
+    infinite = (np.isposinf(C_a), np.isposinf(C_n), np.isposinf(prior_influence))
+
+    if sum(infinite) > 1:
+        raise ValueError("At most one of C_a, C_n and prior_influence can be infinite")
+    if any(infinite):
+        return tuple(1.0 if is_infinite else 0.0 for is_infinite in infinite)
+
+    return C_a, C_n, prior_influence
+
+
 class AADEvaluator(ConiferestEvaluator):
     def __init__(self, aad):
         super(AADEvaluator, self).__init__(aad, map_value=aad.map_value)
         self.C_a = aad.C_a
+        self.C_n = aad.C_n
         self.budget = aad.budget
         self.n_jobs = aad.n_jobs
         self.prior_influence = aad.prior_influence
@@ -24,10 +69,10 @@ class AADEvaluator(ConiferestEvaluator):
         leaf_mask = self.selectors["feature"] < 0
         self.leaf_values = self.selectors["value"][leaf_mask]
 
-    def _q_tau(self, scores):
+    def _q_tau(self, scores, prior_influence):
         if self.budget == "auto":
             # When the regularization is disabled then the problem is degenerate
-            if self.prior_influence == 0:
+            if prior_influence == 0:
                 return 1.0
 
             return None
@@ -73,12 +118,14 @@ class AADEvaluator(ConiferestEvaluator):
 
     def fit_known(self, data, known_data, known_labels, prior_weights=None):
         scores = self.score_samples(data)
-        q_tau = self._q_tau(scores)
-        known_leafs = self.apply(known_data)
 
         n_anomalies = np.count_nonzero(known_labels == Label.ANOMALY)
         n_nominals = np.count_nonzero(known_labels == Label.REGULAR)
         prior_influence = self.prior_influence(n_anomalies, n_nominals)
+        C_a, C_n, prior_influence = _normalize_loss_coefficients(self.C_a, self.C_n, prior_influence)
+
+        q_tau = self._q_tau(scores, prior_influence)
+        known_leafs = self.apply(known_data)
 
         if prior_weights is None:
             prior_weights = self.weights
@@ -99,10 +146,9 @@ class AADEvaluator(ConiferestEvaluator):
         # Problem vector q
         q_known = np.zeros_like(known_labels, dtype=self.weights.dtype)
         if n_anomalies > 0:
-            anomaly_loss = 1.0 if np.isposinf(self.C_a) else self.C_a
-            q_known[known_labels == Label.ANOMALY] = anomaly_loss * np.reciprocal(float(n_anomalies))
-        if n_nominals > 0 and not np.isposinf(self.C_a):
-            q_known[known_labels == Label.REGULAR] = np.reciprocal(float(n_nominals))
+            q_known[known_labels == Label.ANOMALY] = C_a * np.reciprocal(float(n_anomalies))
+        if n_nominals > 0:
+            q_known[known_labels == Label.REGULAR] = C_n * np.reciprocal(float(n_nominals))
 
         q = np.concatenate(
             [
@@ -180,14 +226,14 @@ class AADForest(Coniferest):
        \mathbf{w} = \arg\min_{\mathbf{w}} \left(
         \frac{C_a}{\left|\mathcal{A}\right|}
             \sum_{i \in \mathcal{A}} \mathrm{ReLU}\left(s(\mathbf{x_i} | \mathbf{w}) - q_{\tau}\right) +
-        \frac{1}{\left|\mathcal{N}\right|}
+        \frac{C_n}{\left|\mathcal{N}\right|}
             \sum_{i \in \mathcal{N}} \mathrm{ReLU}\left(q_{\tau} - s(\mathbf{x_i} | \mathbf{w})\right) +
         \frac{\alpha}{2} \lVert \mathbf{w} - \mathbf{w_0}\rVert^2\right),
 
-    where :math:`C_a` is `C_a`, regularization parameter :math:`\alpha` is
-    `prior_influence`, :math:`\mathcal{A}` is a set of known anomalies,
-    :math:`\mathcal{N}` is a set of known nominals, :math:`s(\mathbf{x_i} |
-    \mathbf{w})` is the anomaly score of instance with features
+    where :math:`C_a` is `C_a`, :math:`C_n` is `C_n`, regularization parameter
+    :math:`\alpha` is `prior_influence`, :math:`\mathcal{A}` is a set of known
+    anomalies, :math:`\mathcal{N}` is a set of known nominals,
+    :math:`s(\mathbf{x_i} | \mathbf{w})` is the anomaly score of instance with features
     :math:`\mathbf{x_i}` given weights :math:`\mathbf{w}`.
 
     This problem is reformulated as an equivalent quadratic programming problem:
@@ -199,7 +245,7 @@ class AADForest(Coniferest):
        \mathbf{u}
        \end{bmatrix} = \arg\min_{\mathbf{w}, \mathbf{u}} \left(
         \frac{C_a}{\left|\mathcal{A}\right|} \sum_{i \in \mathcal{A}} u_i +
-        \frac{1}{\left|\mathcal{N}\right|} \sum_{i \in \mathcal{N}} u_i +
+        \frac{C_n}{\left|\mathcal{N}\right|} \sum_{i \in \mathcal{N}} u_i +
         \frac{\alpha}{2} \lVert \mathbf{w} - \mathbf{w_0} \rVert^2\right),
 
     with the following convex constraints:
@@ -233,8 +279,14 @@ class AADForest(Coniferest):
     random_seed : int or None, optional
         Random seed to use for reproducibility. If None - random seed is used.
 
+    C_a : float, optional
+        An anomaly loss coefficient value in the loss function. Default is 1.0.
+
+    C_n : float, optional
+        A nominal loss coefficient value in the loss function. Default is 1.0.
+
     prior_influence : float or callable, optional
-        An regularization coefficient value in the loss functioin. Default is 1.0.
+        A regularization coefficient value in the loss function. Default is 1.0.
         Signature: '(anomaly_count, nominal_count) -> float'
 
     map_value : ["const", "exponential", "linear", "reciprocal"] or callable, optional
@@ -249,6 +301,7 @@ class AADForest(Coniferest):
         max_depth=None,
         budget="auto",
         C_a=1.0,
+        C_n=1.0,
         prior_influence=1.0,
         n_jobs=-1,
         random_seed=None,
@@ -269,11 +322,15 @@ class AADForest(Coniferest):
             raise ValueError('budget must be an int or float or "auto"')
 
         self.budget = budget
-        self.C_a = C_a
 
         if isinstance(prior_influence, Callable):
-            self.prior_influence = prior_influence
+            self.C_a, self.C_n, label_loss_is_infinite = _normalize_label_loss_coefficients(C_a, C_n)
+            if label_loss_is_infinite:
+                self.prior_influence = lambda anomaly_count, nominal_count: 0.0
+            else:
+                self.prior_influence = prior_influence
         elif isinstance(prior_influence, Real):
+            self.C_a, self.C_n, prior_influence = _normalize_loss_coefficients(C_a, C_n, prior_influence)
             self.prior_influence = lambda anomaly_count, nominal_count: prior_influence
         else:
             raise ValueError("prior_influence is neither a callable nor a constant")

--- a/src/coniferest/aadforest.py
+++ b/src/coniferest/aadforest.py
@@ -99,8 +99,9 @@ class AADEvaluator(ConiferestEvaluator):
         # Problem vector q
         q_known = np.zeros_like(known_labels, dtype=self.weights.dtype)
         if n_anomalies > 0:
-            q_known[known_labels == Label.ANOMALY] = self.C_a * np.reciprocal(float(n_anomalies))
-        if n_nominals > 0:
+            anomaly_loss = 1.0 if np.isposinf(self.C_a) else self.C_a
+            q_known[known_labels == Label.ANOMALY] = anomaly_loss * np.reciprocal(float(n_anomalies))
+        if n_nominals > 0 and not np.isposinf(self.C_a):
             q_known[known_labels == Label.REGULAR] = np.reciprocal(float(n_nominals))
 
         q = np.concatenate(

--- a/src/coniferest/aadforest.py
+++ b/src/coniferest/aadforest.py
@@ -12,33 +12,18 @@ from .label import Label
 __all__ = ["AADForest"]
 
 
-def _validate_coefficient(value, name):
+def _validate_coefficient(value, name, *, allow_infinite=True):
     if not isinstance(value, Real):
         raise ValueError(f"{name} is not a real number")
 
     value = float(value)
 
-    if np.isnan(value) or np.isneginf(value):
-        raise ValueError(f"{name} must be finite or positive infinity")
+    if np.isnan(value) or value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    if not allow_infinite and np.isposinf(value):
+        raise ValueError(f"{name} must be finite")
 
     return value
-
-
-def _normalize_label_loss_coefficients(C_a, C_n):
-    C_a = _validate_coefficient(C_a, "C_a")
-    C_n = _validate_coefficient(C_n, "C_n")
-
-    infinite_C_a = np.isposinf(C_a)
-    infinite_C_n = np.isposinf(C_n)
-
-    if infinite_C_a and infinite_C_n:
-        raise ValueError("At most one of C_a, C_n and prior_influence can be infinite")
-    if infinite_C_a:
-        return 1.0, 0.0, True
-    if infinite_C_n:
-        return 0.0, 1.0, True
-
-    return C_a, C_n, False
 
 
 def _normalize_loss_coefficients(C_a, C_n, prior_influence):
@@ -122,7 +107,7 @@ class AADEvaluator(ConiferestEvaluator):
         n_anomalies = np.count_nonzero(known_labels == Label.ANOMALY)
         n_nominals = np.count_nonzero(known_labels == Label.REGULAR)
         prior_influence = self.prior_influence(n_anomalies, n_nominals)
-        C_a, C_n, prior_influence = _normalize_loss_coefficients(self.C_a, self.C_n, prior_influence)
+        prior_influence = _validate_coefficient(prior_influence, "prior_influence", allow_infinite=False)
 
         q_tau = self._q_tau(scores, prior_influence)
         known_leafs = self.apply(known_data)
@@ -146,9 +131,9 @@ class AADEvaluator(ConiferestEvaluator):
         # Problem vector q
         q_known = np.zeros_like(known_labels, dtype=self.weights.dtype)
         if n_anomalies > 0:
-            q_known[known_labels == Label.ANOMALY] = C_a * np.reciprocal(float(n_anomalies))
+            q_known[known_labels == Label.ANOMALY] = self.C_a * np.reciprocal(float(n_anomalies))
         if n_nominals > 0:
-            q_known[known_labels == Label.REGULAR] = C_n * np.reciprocal(float(n_nominals))
+            q_known[known_labels == Label.REGULAR] = self.C_n * np.reciprocal(float(n_nominals))
 
         q = np.concatenate(
             [
@@ -324,8 +309,8 @@ class AADForest(Coniferest):
         self.budget = budget
 
         if isinstance(prior_influence, Callable):
-            self.C_a, self.C_n, label_loss_is_infinite = _normalize_label_loss_coefficients(C_a, C_n)
-            if label_loss_is_infinite:
+            self.C_a, self.C_n, normalized_prior_influence = _normalize_loss_coefficients(C_a, C_n, 1.0)
+            if normalized_prior_influence == 0.0:
                 self.prior_influence = lambda anomaly_count, nominal_count: 0.0
             else:
                 self.prior_influence = prior_influence

--- a/src/coniferest/aadforest.py
+++ b/src/coniferest/aadforest.py
@@ -41,6 +41,17 @@ def _normalize_loss_coefficients(C_a, C_n, prior_influence):
     return C_a, C_n, prior_influence
 
 
+def _validated_prior_influence(prior_influence):
+    def inner(anomaly_count, nominal_count):
+        return _validate_coefficient(
+            prior_influence(anomaly_count, nominal_count),
+            "prior_influence",
+            allow_infinite=False,
+        )
+
+    return inner
+
+
 class AADEvaluator(ConiferestEvaluator):
     def __init__(self, aad):
         super(AADEvaluator, self).__init__(aad, map_value=aad.map_value)
@@ -107,7 +118,6 @@ class AADEvaluator(ConiferestEvaluator):
         n_anomalies = np.count_nonzero(known_labels == Label.ANOMALY)
         n_nominals = np.count_nonzero(known_labels == Label.REGULAR)
         prior_influence = self.prior_influence(n_anomalies, n_nominals)
-        prior_influence = _validate_coefficient(prior_influence, "prior_influence", allow_infinite=False)
 
         q_tau = self._q_tau(scores, prior_influence)
         known_leafs = self.apply(known_data)
@@ -313,7 +323,7 @@ class AADForest(Coniferest):
             if normalized_prior_influence == 0.0:
                 self.prior_influence = lambda anomaly_count, nominal_count: 0.0
             else:
-                self.prior_influence = prior_influence
+                self.prior_influence = _validated_prior_influence(prior_influence)
         elif isinstance(prior_influence, Real):
             self.C_a, self.C_n, prior_influence = _normalize_loss_coefficients(C_a, C_n, prior_influence)
             self.prior_influence = lambda anomaly_count, nominal_count: prior_influence

--- a/tests/test_aadforest.py
+++ b/tests/test_aadforest.py
@@ -126,6 +126,7 @@ def test_invalid_callable_prior_influence_raises():
     with pytest.raises(ValueError, match="prior_influence"):
         forest.fit_known(data, known_data=known_data, known_labels=known_labels)
 
+
 @pytest.mark.regression
 def test_budget_auto(regression_data):
     data, _metadata = single_outlier()

--- a/tests/test_aadforest.py
+++ b/tests/test_aadforest.py
@@ -3,6 +3,7 @@ import pytest
 
 from coniferest.aadforest import AADForest
 from coniferest.datasets import single_outlier
+from coniferest.label import Label
 
 
 def test_scores_negative():
@@ -38,6 +39,49 @@ def test_prior_influence_callable():
     scores = forest.score_samples(data)
     # Outlier goes last and must have the lowest score
     assert np.argmin(scores) == data.shape[0] - 1
+
+
+def test_infinite_c_a_produces_finite_scores():
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((64, 4))
+    known_data = data[[0, 1, 2]]
+    known_labels = np.array([Label.ANOMALY, Label.REGULAR, Label.REGULAR])
+
+    forest = AADForest(n_trees=10, n_subsamples=32, random_seed=0, C_a=np.inf, budget=0.1, n_jobs=1)
+    forest.fit_known(data, known_data=known_data, known_labels=known_labels)
+
+    assert np.all(np.isfinite(forest.evaluator.weights))
+    assert np.all(np.isfinite(forest.score_samples(data)))
+
+
+def test_infinite_c_a_ignores_nominal_loss():
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((64, 4))
+    known_data = data[[0, 1, 2]]
+    known_labels = np.array([Label.ANOMALY, Label.REGULAR, Label.REGULAR])
+    anomaly_only_labels = np.array([Label.ANOMALY, Label.UNKNOWN, Label.UNKNOWN])
+    forest_params = {
+        "n_trees": 10,
+        "n_subsamples": 32,
+        "random_seed": 0,
+        "C_a": np.inf,
+        "budget": 0.1,
+        "n_jobs": 1,
+    }
+
+    forest = AADForest(**forest_params).fit_known(data, known_data=known_data, known_labels=known_labels)
+    anomaly_only_forest = AADForest(**forest_params).fit_known(
+        data,
+        known_data=known_data,
+        known_labels=anomaly_only_labels,
+    )
+
+    np.testing.assert_allclose(
+        forest.score_samples(data),
+        anomaly_only_forest.score_samples(data),
+        rtol=1e-5,
+        atol=1e-7,
+    )
 
 
 @pytest.mark.regression

--- a/tests/test_aadforest.py
+++ b/tests/test_aadforest.py
@@ -6,6 +6,15 @@ from coniferest.datasets import single_outlier
 from coniferest.label import Label
 
 
+def infinite_coefficient_data():
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((64, 4))
+    known_data = data[[0, 1, 2]]
+    known_labels = np.array([Label.ANOMALY, Label.REGULAR, Label.REGULAR])
+
+    return data, known_data, known_labels
+
+
 def test_scores_negative():
     data = np.arange(1024.0).reshape(256, 4)
     forest = AADForest(n_trees=10, random_seed=0).fit(data)
@@ -42,10 +51,7 @@ def test_prior_influence_callable():
 
 
 def test_infinite_c_a_produces_finite_scores():
-    rng = np.random.default_rng(0)
-    data = rng.standard_normal((64, 4))
-    known_data = data[[0, 1, 2]]
-    known_labels = np.array([Label.ANOMALY, Label.REGULAR, Label.REGULAR])
+    data, known_data, known_labels = infinite_coefficient_data()
 
     forest = AADForest(n_trees=10, n_subsamples=32, random_seed=0, C_a=np.inf, budget=0.1, n_jobs=1)
     forest.fit_known(data, known_data=known_data, known_labels=known_labels)
@@ -54,35 +60,71 @@ def test_infinite_c_a_produces_finite_scores():
     assert np.all(np.isfinite(forest.score_samples(data)))
 
 
-def test_infinite_c_a_ignores_nominal_loss():
-    rng = np.random.default_rng(0)
-    data = rng.standard_normal((64, 4))
-    known_data = data[[0, 1, 2]]
-    known_labels = np.array([Label.ANOMALY, Label.REGULAR, Label.REGULAR])
-    anomaly_only_labels = np.array([Label.ANOMALY, Label.UNKNOWN, Label.UNKNOWN])
-    forest_params = {
-        "n_trees": 10,
-        "n_subsamples": 32,
-        "random_seed": 0,
-        "C_a": np.inf,
-        "budget": 0.1,
-        "n_jobs": 1,
-    }
+@pytest.mark.parametrize(
+    ("infinite_params", "normalized_params"),
+    [
+        ({"C_a": np.inf}, {"C_a": 1.0, "C_n": 0.0, "prior_influence": 0.0}),
+        ({"C_n": np.inf}, {"C_a": 0.0, "C_n": 1.0, "prior_influence": 0.0}),
+        ({"prior_influence": np.inf}, {"C_a": 0.0, "C_n": 0.0, "prior_influence": 1.0}),
+        (
+            {"prior_influence": lambda anomaly_count, nominal_count: np.inf},
+            {"C_a": 0.0, "C_n": 0.0, "prior_influence": 1.0},
+        ),
+    ],
+)
+def test_infinite_coefficient_matches_normalized_loss(infinite_params, normalized_params):
+    data, known_data, known_labels = infinite_coefficient_data()
+    forest_params = dict(
+        n_trees=10,
+        n_subsamples=32,
+        random_seed=0,
+        budget=0.1,
+        n_jobs=1,
+    )
 
-    forest = AADForest(**forest_params).fit_known(data, known_data=known_data, known_labels=known_labels)
-    anomaly_only_forest = AADForest(**forest_params).fit_known(
+    forest = AADForest(**(forest_params | infinite_params)).fit_known(
         data,
         known_data=known_data,
-        known_labels=anomaly_only_labels,
+        known_labels=known_labels,
+    )
+    normalized_forest = AADForest(**(forest_params | normalized_params)).fit_known(
+        data,
+        known_data=known_data,
+        known_labels=known_labels,
     )
 
     np.testing.assert_allclose(
         forest.score_samples(data),
-        anomaly_only_forest.score_samples(data),
+        normalized_forest.score_samples(data),
         rtol=1e-5,
         atol=1e-7,
     )
 
+
+@pytest.mark.parametrize(
+    "forest_params",
+    [
+        {"C_a": np.inf, "C_n": np.inf},
+        {"C_a": np.inf, "prior_influence": np.inf},
+        {"C_n": np.inf, "prior_influence": np.inf},
+    ],
+)
+def test_multiple_infinite_coefficients_raise(forest_params):
+    with pytest.raises(ValueError, match="At most one"):
+        AADForest(**forest_params)
+
+
+def test_invalid_callable_prior_influence_raises():
+    data, known_data, known_labels = infinite_coefficient_data()
+    forest = AADForest(
+        n_trees=10,
+        n_subsamples=32,
+        random_seed=0,
+        prior_influence=lambda anomaly_count, nominal_count: np.nan,
+    )
+
+    with pytest.raises(ValueError, match="prior_influence"):
+        forest.fit_known(data, known_data=known_data, known_labels=known_labels)
 
 @pytest.mark.regression
 def test_budget_auto(regression_data):

--- a/tests/test_aadforest.py
+++ b/tests/test_aadforest.py
@@ -66,10 +66,6 @@ def test_infinite_c_a_produces_finite_scores():
         ({"C_a": np.inf}, {"C_a": 1.0, "C_n": 0.0, "prior_influence": 0.0}),
         ({"C_n": np.inf}, {"C_a": 0.0, "C_n": 1.0, "prior_influence": 0.0}),
         ({"prior_influence": np.inf}, {"C_a": 0.0, "C_n": 0.0, "prior_influence": 1.0}),
-        (
-            {"prior_influence": lambda anomaly_count, nominal_count: np.inf},
-            {"C_a": 0.0, "C_n": 0.0, "prior_influence": 1.0},
-        ),
     ],
 )
 def test_infinite_coefficient_matches_normalized_loss(infinite_params, normalized_params):
@@ -114,16 +110,40 @@ def test_multiple_infinite_coefficients_raise(forest_params):
         AADForest(**forest_params)
 
 
-def test_invalid_callable_prior_influence_raises():
+@pytest.mark.parametrize(
+    "forest_params",
+    [
+        {"C_a": -1.0},
+        {"C_a": -np.inf},
+        {"C_n": -1.0},
+        {"C_n": -np.inf},
+        {"prior_influence": -1.0},
+        {"prior_influence": -np.inf},
+    ],
+)
+def test_negative_coefficients_raise(forest_params):
+    with pytest.raises(ValueError, match="non-negative"):
+        AADForest(**forest_params)
+
+
+@pytest.mark.parametrize(
+    "prior_influence",
+    [
+        lambda anomaly_count, nominal_count: np.nan,
+        lambda anomaly_count, nominal_count: -1.0,
+        lambda anomaly_count, nominal_count: np.inf,
+    ],
+)
+def test_invalid_callable_prior_influence_raises(prior_influence):
     data, known_data, known_labels = infinite_coefficient_data()
     forest = AADForest(
         n_trees=10,
         n_subsamples=32,
         random_seed=0,
-        prior_influence=lambda anomaly_count, nominal_count: np.nan,
+        prior_influence=prior_influence,
     )
 
-    with pytest.raises(ValueError, match="prior_influence"):
+    with pytest.raises(ValueError):
         forest.fit_known(data, known_data=known_data, known_labels=known_labels)
 
 


### PR DESCRIPTION
Fixes #258.

This handles the C_a=+np.inf AAD edge case without passing non-finite coefficients to the QP solver. In that limit, anomaly loss remains normalized while nominal loss is ignored, matching the issue description.

Added regression coverage for:
- finite weights and scores after fit_known with C_a=np.inf
- equivalence between mixed anomaly/regular labels and anomaly-only labels when nominal loss is ignored

Local checks:
- .venv/bin/python -m pytest tests/test_aadforest.py::test_infinite_c_a_produces_finite_scores tests/test_aadforest.py::test_infinite_c_a_ignores_nominal_loss -q
- .venv/bin/python -m pytest tests/test_aadforest.py -m "not long" -q
- .venv/bin/python -m ruff check src/coniferest/aadforest.py tests/test_aadforest.py
- PY_IGNORE_IMPORTMISMATCH=1 .venv/bin/python -m pytest tests -m "not long" -q: 27 passed, 1 failed due to SSL certificate verification while downloading external DevNet dataset