### PR TITLE
Improve HTML documentation style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,13 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import importlib
+import inspect
+import pathlib
+import subprocess
+
+import coniferest
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -10,13 +17,16 @@ project = "coniferest"
 copyright = "2024, SNAD team"
 author = "SNAD team"
 
+GITHUB_REPO = "snad-space/coniferest"
+GITHUB_URL = f"https://github.com/{GITHUB_REPO}"
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "nbsphinx",
     "sphinx_copybutton",
 ]
@@ -28,7 +38,71 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "alabaster"
+html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
+html_logo = "../images/CF_logo_green_sign_universal.svg"
+html_title = "coniferest"
+
+html_theme_options = {
+    "repository_url": GITHUB_URL,
+    "repository_branch": "master",
+    "path_to_docs": "docs",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_download_button": True,
+    "use_fullscreen_button": True,
+    "launch_buttons": {
+        "colab_url": "https://colab.research.google.com",
+        "notebook_interface": "jupyterlab",
+    },
+    "show_toc_level": 2,
+}
 
 nbsphinx_execute = 'never'
+
+
+# -- Options for linkcode extension -------------------------------------------
+# Point API doc "source" links to GitHub instead of embedding a local copy.
+
+try:
+    _GIT_SHA = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=pathlib.Path(__file__).resolve().parent,
+    ).decode().strip()
+except Exception:
+    _GIT_SHA = f"v{coniferest.__version__}"
+
+
+def linkcode_resolve(domain, info):
+    if domain != "py" or not info["module"]:
+        return None
+
+    module_name = info["module"]
+    fullname = info["fullname"]
+
+    try:
+        module = importlib.import_module(module_name)
+        obj = module
+        for part in fullname.split("."):
+            obj = getattr(obj, part)
+        obj = inspect.unwrap(obj)
+    except Exception:
+        return None
+
+    try:
+        source_file = inspect.getsourcefile(obj)
+        source_lines, start_line = inspect.getsourcelines(obj)
+    except (TypeError, OSError):
+        return None
+
+    if source_file is None:
+        return None
+
+    try:
+        rel_path = pathlib.Path(source_file).resolve().relative_to(
+            pathlib.Path(coniferest.__file__).resolve().parent.parent
+        )
+    except ValueError:
+        return None
+
+    end_line = start_line + len(source_lines) - 1
+    return f"{GITHUB_URL}/blob/{_GIT_SHA}/src/{rel_path.as_posix()}#L{start_line}-L{end_line}"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,56 @@
-.. coniferest documentation master file, created by
-   sphinx-quickstart on Fri May 26 15:16:22 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+coniferest
+==========
 
-Welcome to coniferest's documentation!
-======================================
+**coniferest** is a package for active anomaly detection with isolation forests, made by the `SNAD collaboration <https://snad.space/>`_.
+
+It includes:
+
+- :class:`IsolationForest <coniferest.isoforest.IsolationForest>` — a reimplementation of scikit-learn's isolation forest with much better scoring performance, thanks to the use of the Rust programming language and multi-threading.
+- :class:`AADForest <coniferest.aadforest.AADForest>` — a reimplementation of the Active Anomaly Detection algorithm with isolation forests from Shubhomoy Das' `ad_examples <https://github.com/shubhomoydas/ad_examples>`_ package, with better performance, much less code and more flexible dependencies.
+- :class:`PineForest <coniferest.pineforest.PineForest>` — our own active learning model based on the idea of tree filtering.
+
+Installation
+------------
+
+.. code-block:: bash
+
+    python3 -mpip install coniferest
+
+Binary wheels are available for Linux, macOS and Windows, so the package can be installed from PyPI on these platforms with no build-time dependencies.
+See the :doc:`tutorial` for a complete walk-through, including building from source.
+
+Getting started
+----------------
+
+- :doc:`tutorial` — install the package and run your first isolation forest and active anomaly detection session.
+- :doc:`isoforest` — details on the isolation forest implementation.
+- :doc:`pariou` — active anomaly detection on the Pariou active learning benchmark.
+- :doc:`notebooks` — worked examples and workshop tutorials as Jupyter notebooks.
+- :doc:`modules` — full API reference.
+
+Citation
+--------
+
+If you found this project useful for your research, please cite `Kornilov, Korolev, Malanchev, et al., 2025 <https://doi.org/10.1016/j.ascom.2025.100960>`_:
+
+.. code-block:: bibtex
+
+    @article{Kornilov2025,
+        title = {Coniferest: A complete active anomaly detection framework},
+        journal = {Astronomy and Computing},
+        volume = {52},
+        pages = {100960},
+        year = {2025},
+        issn = {2213-1337},
+        doi = {10.1016/j.ascom.2025.100960},
+        url = {https://www.sciencedirect.com/science/article/pii/S2213133725000332},
+        author = {M.V. Kornilov and V.S. Korolev and K.L. Malanchev and A.D. Lavrukhina and E. Russeil and T.A. Semenikhin and E. Gangler and E.E.O. Ishida and M.V. Pruzhinskaya and A.A. Volnova and S. Sreejith},
+    }
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   :hidden:
 
    tutorial.rst
    isoforest.rst
@@ -17,7 +59,7 @@ Welcome to coniferest's documentation!
    modules.rst
 
 Indices and tables
-==================
+===================
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,9 +23,9 @@ Getting started
 ----------------
 
 - :doc:`tutorial` — install the package and run your first isolation forest and active anomaly detection session.
-- :doc:`isoforest` — details on the isolation forest implementation.
-- :doc:`pariou` — active anomaly detection on the Pariou active learning benchmark.
 - :doc:`notebooks` — worked examples and workshop tutorials as Jupyter notebooks.
+- :doc:`isoforest` — details on the isolation forest implementation.
+- :doc:`pariou` — mathematical background of anomaly detection feature signatures.
 - :doc:`modules` — full API reference.
 
 Citation

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx-autoapi
+sphinx-book-theme
 sphinx-copybutton
 nbsphinx
 ipython


### PR DESCRIPTION
Rendered: https://coniferest--360.org.readthedocs.build/en/360/

- Switch docs theme to `sphinx_book_theme`
- Add project logo to the sidebar
- Rewrite the landing page (`index.rst`) with a project overview, install snippet, and navigation
- Add paper citation (bibtex) to the landing page
- Add a GitHub repository button and issues button to the navbar
- Change API doc "source" links to point to GitHub (`sphinx.ext.linkcode` instead of `viewcode`), linking to exact lines at the built commit SHA
- Add "Open in Colab" and "download .ipynb" buttons to notebook pages
- Enable the "on this page" contents sidebar (`show_toc_level`)

Closes #235