### PR TITLE
Lower default sampletrees_per_batch from 2^20 to 2^14

### DIFF
--- a/src/coniferest/aadforest.py
+++ b/src/coniferest/aadforest.py
@@ -264,7 +264,7 @@ class AADForest(Coniferest):
         prior_influence=0.0,
         n_jobs=-1,
         random_seed=None,
-        sampletrees_per_batch=1 << 20,
+        sampletrees_per_batch=1 << 14,
         map_value=None,
     ):
         super().__init__(

--- a/src/coniferest/coniferest.py
+++ b/src/coniferest/coniferest.py
@@ -47,7 +47,7 @@ class Coniferest(ABC):
         max_depth=None,
         n_jobs=-1,
         random_seed=None,
-        sampletrees_per_batch=1 << 20,
+        sampletrees_per_batch=1 << 14,
     ):
         self.core_forest = core_forest
         self.n_subsamples = n_subsamples

--- a/src/coniferest/isoforest.py
+++ b/src/coniferest/isoforest.py
@@ -42,7 +42,7 @@ class IsolationForest(Coniferest):
         max_depth=None,
         n_jobs=-1,
         random_seed=None,
-        sampletrees_per_batch=1 << 20,
+        sampletrees_per_batch=1 << 14,
     ):
         super().__init__(
             n_subsamples=n_subsamples,

--- a/src/coniferest/pineforest.py
+++ b/src/coniferest/pineforest.py
@@ -69,7 +69,7 @@ class PineForest(Coniferest):
         weight_ratio=1.0,
         n_jobs=-1,
         random_seed=None,
-        sampletrees_per_batch=1 << 20,
+        sampletrees_per_batch=1 << 14,
     ):
         super().__init__(
             n_subsamples=n_subsamples,


### PR DESCRIPTION
Stacked on #376, which reduces overhead of multithreaded calculations by reusing the same thread pool.

The description of optimization experiment by Claude is following:

## Tuning experiment
Swept `sampletrees_per_batch` over `2^10..2^22` scoring **500k rows** through a **128-tree** `IsolationForest`; **mean of 7 runs, 95% t confidence intervals**; three machines × three `n_jobs` (2, 8, −1=all cores). Remote machines were driven through their **Docker context** (not SSH):

| machine | cores | arch |
|---|---|---|
| local | 12 | arm64/macOS (Apple Silicon) |
| rock5 | 8 | arm64/Linux (RK3588) |
| cyg | 48 | x86_64/Linux (Xeon) |

**Cost of the old `2^20` default vs the best batch size found:**

| | n_jobs=2 | n_jobs=8 | n_jobs=−1 |
|---|---|---|---|
| local (12c) | ~flat | +7% | +11% |
| rock5 (8c) | ~flat | +6% | +6% |
| cyg (48c) | ~flat | +1.5% | **+45%** |

The penalty is negligible at `n_jobs=2` (two workers stay busy regardless) but grows with core count. On cyg with all 48 cores the old default ran **45% slower** than optimal (`2^22` was +121%). The optimum is a broad `2^10..2^16` plateau on every machine; coarse batches (≥`2^18`) are what hurt, and finer batches showed no overhead penalty (the single-batch serial fallback from #376 already handles tiny scoring calls).